### PR TITLE
IOS-XR: detect failed config, discard uncommitted changes to allow exit.

### DIFF
--- a/netdev/vendors/cisco/cisco_iosxr.py
+++ b/netdev/vendors/cisco/cisco_iosxr.py
@@ -33,6 +33,14 @@ class CiscoIOSXR(IOSLikeDevice):
             self._stdin.write(self._normalize_cmd(commit))
             output += await self._read_until_prompt()
 
+        if "Please issue 'show configuration failed" in output:
+            reason = await self.send_command('show configuration failed')
+            logger.error('Errors applying config: %s', reason)
+            output += reason
+            if exit_config_mode:
+                logger.debug('Aborting uncommitted changes.')
+                output += await self.send_command('abort')
+
         if exit_config_mode:
             output += await self.exit_config_mode()
 


### PR DESCRIPTION
Hi @selfuryon 

I know we discussed a bunch of stuff in #4, but the truth is that in the short term, the changes in this PR resolve my current headaches with IOS-XR, with much less work than would be required to implement our ideas in #4.

My proposal is that all we do is

1. Check for the `Please issue 'show configuration failed [inheritance]'` line, and then 
2. Run `show configuration failed` in order to obtain the actual error message for the output, and then
3. Run `abort` to discard uncommitted changes.  (This completely gets rid of dealing with the "uncommitted changes (yes/no/cancel)" interactive prompt that happens when it tries to exit config mode, as detailed in #4)

I've tested the code in this PR on several of my XR devices, with different kinds of config problems, and it works for all of them: I get the error detail in the output message, and I don't have long timeout problems associated with the situation I described in #4.

What are your thoughts?