### PR TITLE
New device added: Cisco SG3XX switch family

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,14 @@ Requires:
 * pyYAML
   
  
-Supports: 
+Supports:
 ---------
 * Cisco IOS 
 * Cisco IOS XE
 * Cisco IOS XR
 * Cisco ASA
-* Cisco NX-OS 
+* Cisco NX-OS
+* Cisco SG3XX
 * HP Comware (like V1910 too)
 * Fujitsu Blade Switches
 * Mikrotik RouterOS

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Supports:
 * Aruba AOS 6.X
 * Aruba AOS 8.X
 * Terminal
+* Alcatel AOS
 
 Examples:
 ---------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -150,3 +150,10 @@ Terminal
 .. autoclass:: Terminal
    :members:
    :inherited-members:
+
+AlcatelAOS
+~~~~~~~~
+
+.. autoclass:: AlcatelAOS
+   :members:
+   :inherited-members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,6 +88,13 @@ CiscoNXOS
    :members:
    :inherited-members:
 
+CiscoSG3XX
+~~~~~~~~~
+
+.. autoclass:: CiscoSG3XX
+   :members:
+   :inherited-members:
+
 FujitsuSwitch
 ~~~~~~~~~~~~~
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -95,3 +95,7 @@ Juniper JunOS example
 Terminal example
 ----------------
 .. literalinclude:: ../examples/terminal.py
+
+Alcatel AOS example
+----------------
+.. literalinclude:: ../examples/alcatel_aos.py

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -60,6 +60,10 @@ IOS XR example
 --------------
 .. literalinclude:: ../examples/cisco_iosxr.py
 
+IOS SG3XX example
+--------------
+.. literalinclude:: ../examples/cisco_sg3xx.py
+
 Fujitsu example
 ---------------
 .. literalinclude:: ../examples/fujitsu_switch.py

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -67,11 +67,13 @@ All other classes are the end classes which you can use for working with particu
 * :class:`CiscoIOSXR`
 * :class:`CiscoASA`
 * :class:`CiscoNXOS`
+* :class:`CiscoSG3XX`
 * :class:`FujitsuSwitch`
 * :class:`HPComware`
 * :class:`HPComwareLimited`
 * :class:`AristaEOS`
 * :class:`JuniperJunOS`
+* :class:`AlcatelAOS`
 
 The particular class selected by parameter *device_type* in :func:`create`
 

--- a/examples/alcatel_aos.py
+++ b/examples/alcatel_aos.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Import Python library
+import asyncio, netdev
+
+# Coroutine used for the tasks
+async def task(param):
+
+    # Create an object for the devices and open SSH connections
+    async with netdev.create(**param) as device:
+
+        # Testing sending simple command
+        
+        # Command to send
+        cmd = "show system"
+
+        # Sending command
+        output = await device.send_command(cmd)
+
+        # Display the output
+        print(output)
+
+        # Display separator
+        print("*" * 80)
+
+        # Testing sending configuration set
+
+        # Commands to send
+        commands = ["vlan 3000", "no vlan 3001"]
+
+        # Sending command
+        output = await device.send_config_set(commands)
+
+        # Display the output
+        print(output)
+
+
+# Main coroutine
+async def main():
+
+    # Parameters of the network device
+    my_device = {   'username' : 'LOGIN',
+                    'password' : 'PASSWORD',
+                    'host': 'IP_ADDRESS',
+                    'device_type': 'alcatel_aos',
+    }
+
+    # List of devices
+    devices = [my_device]
+    
+    # List of tasks
+    my_tasks = [task(dev) for dev in devices]
+    
+    # Starting the coroutine of the tasks
+    await asyncio.wait(my_tasks)
+
+
+# Main function call
+if __name__ == '__main__':
+
+    # Run the main coroutine
+    asyncio.run(main())
+
+    '''
+    Result:
+    ********************************************************************************
+    System:
+    Description:  Alcatel-Lucent Enterprise OS6860E-48 8.4.1.141.R03 GA, December 07, 2017.,
+    Object ID:    1.3.6.1.4.1.6486.801.1.1.2.1.11.1.7,
+    Up Time:      5 days 5 hours 3 minutes and 56 seconds,
+    Contact:      Alcatel-Lucent, http://enterprise.alcatel-lucent.com,
+    Name:         switch01,
+    Location:     Somewhere nearby,
+    Services:     78,
+    Date & Time:  SAT AUG 29 2020 18:48:53 (CEST)
+    Flash Space:
+        Primary CMM:
+        Available (bytes):  933896192,
+        Comments         :  None
+
+    ********************************************************************************
+    vlan 3000
+
+    switch01 ==> no vlan 3001
+
+    switch01 ==>
+
+    ********************************************************************************
+
+    '''

--- a/examples/cisco_sg3xx.py
+++ b/examples/cisco_sg3xx.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Import Python library
+import asyncio, netdev
+
+# Coroutine used for the tasks
+async def task(param):
+
+    # Create an object for the devices and open SSH connections
+    async with netdev.create(**param) as ios:
+
+        # Testing sending simple command
+        
+        # Command to send
+        cmd = "show clock"
+
+        # Sending command
+        output = await ios.send_command(cmd)
+
+        # Display the output
+        print(output)
+
+# Main coroutine
+async def main():
+
+    # Parameters of the network device
+    my_device = {   'username' : 'LOGIN',
+                    'password' : 'PASSWORD',
+                    'host': 'IP_ADDRESS',
+                    'device_type': 'cisco_sg3xx',
+    }
+
+    # List of devices
+    devices = [my_device]
+    
+    # List of tasks
+    my_tasks = [task(dev) for dev in devices]
+    
+    # Starting the coroutine of the tasks
+    await asyncio.wait(my_tasks)
+
+
+# Main function call
+if __name__ == '__main__':
+
+    # Run the main coroutine
+    asyncio.run(main())
+
+    '''
+    Result:
+    ********************************************************************************
+    .14:07:35 J  Aug 28 2020
+    Time source is sntp
+    Time from Browser is disabled
+    ********************************************************************************
+
+    '''

--- a/netdev/dispatcher.py
+++ b/netdev/dispatcher.py
@@ -3,7 +3,7 @@ Factory function for creating netdev classes
 """
 from netdev.vendors import AristaEOS
 from netdev.vendors import ArubaAOS6, ArubaAOS8
-from netdev.vendors import CiscoASA, CiscoIOS, CiscoIOSXR, CiscoNXOS
+from netdev.vendors import CiscoASA, CiscoIOS, CiscoIOSXR, CiscoNXOS, CiscoSG3XX
 from netdev.vendors import FujitsuSwitch
 from netdev.vendors import HPComware, HPComwareLimited
 from netdev.vendors import JuniperJunOS
@@ -23,6 +23,7 @@ CLASS_MAPPER = {
     "cisco_ios_xe": CiscoIOS,
     "cisco_ios_xr": CiscoIOSXR,
     "cisco_nxos": CiscoNXOS,
+    "cisco_sg3xx": CiscoSG3XX,
     "fujitsu_switch": FujitsuSwitch,
     "hp_comware": HPComware,
     "hp_comware_limited": HPComwareLimited,

--- a/netdev/dispatcher.py
+++ b/netdev/dispatcher.py
@@ -1,6 +1,7 @@
 """
 Factory function for creating netdev classes
 """
+from netdev.vendors import AlcatelAOS
 from netdev.vendors import AristaEOS
 from netdev.vendors import ArubaAOS6, ArubaAOS8
 from netdev.vendors import CiscoASA, CiscoIOS, CiscoIOSXR, CiscoNXOS, CiscoSG3XX
@@ -15,6 +16,7 @@ from netdev.vendors import HW1000
 # @formatter:off
 # The keys of this dictionary are the supported device_types
 CLASS_MAPPER = {
+    "alcatel_aos": AlcatelAOS,
     "arista_eos": AristaEOS,
     "aruba_aos_6": ArubaAOS6,
     "aruba_aos_8": ArubaAOS8,

--- a/netdev/vendors/__init__.py
+++ b/netdev/vendors/__init__.py
@@ -1,7 +1,7 @@
 from netdev.vendors.arista import AristaEOS
 from netdev.vendors.aruba import ArubaAOS8, ArubaAOS6
 from netdev.vendors.base import BaseDevice
-from netdev.vendors.cisco import CiscoNXOS, CiscoIOSXR, CiscoASA, CiscoIOS
+from netdev.vendors.cisco import CiscoNXOS, CiscoIOSXR, CiscoASA, CiscoIOS, CiscoSG3XX
 from netdev.vendors.comware_like import ComwareLikeDevice
 from netdev.vendors.fujitsu import FujitsuSwitch
 from netdev.vendors.hp import HPComware, HPComwareLimited
@@ -18,6 +18,7 @@ __all__ = (
     "CiscoIOS",
     "CiscoIOSXR",
     "CiscoNXOS",
+    "CiscoSG3XX",
     "HPComware",
     "HPComwareLimited",
     "FujitsuSwitch",

--- a/netdev/vendors/__init__.py
+++ b/netdev/vendors/__init__.py
@@ -1,3 +1,4 @@
+from netdev.vendors.alcatel import AlcatelAOS
 from netdev.vendors.arista import AristaEOS
 from netdev.vendors.aruba import ArubaAOS8, ArubaAOS6
 from netdev.vendors.base import BaseDevice
@@ -41,4 +42,5 @@ __all__ = (
     "mikrotik",
     "UbiquityEdgeSwitch",
     "HW1000",
+    "AlcatelAOS",
 )

--- a/netdev/vendors/alcatel/__init__.py
+++ b/netdev/vendors/alcatel/__init__.py
@@ -1,0 +1,3 @@
+from .alcatel_aos import AlcatelAOS
+
+__all__ = ["AlcatelAOS"]

--- a/netdev/vendors/alcatel/alcatel_aos.py
+++ b/netdev/vendors/alcatel/alcatel_aos.py
@@ -1,7 +1,38 @@
 from netdev.vendors.base import BaseDevice
-
+from netdev.logger import logger
+import asyncio
+import re
 
 class AlcatelAOS(BaseDevice):
     """Class for working with Alcatel AOS"""
 
-    pass
+
+    async def _read_until_prompt_or_pattern(self, pattern="", re_flags=0):
+        """Read until either self.base_pattern or pattern is detected. Return ALL data available"""
+        output = ""
+        logger.info("Host {}: Reading until prompt or pattern".format(self._host))
+        if not pattern:
+            pattern = self._base_pattern
+        base_prompt_pattern = self._base_pattern
+        while True:
+            fut = self._stdout.read(self._MAX_BUFFER)
+            try:
+                output += await asyncio.wait_for(fut, self._timeout)
+                #print("123:")
+                #print(output)
+                #print("*" * 80)
+            except asyncio.TimeoutError:
+                raise TimeoutError(self._host)
+            if re.search("\n" + pattern, output, flags=re_flags) or re.search(
+                "\n" + base_prompt_pattern, output, flags=re_flags
+            ):
+            
+            #if re.search("\nrprd-opcinet091 - ADMIN ==> ", output, flags=re_flags):
+            
+                logger.debug(
+                    "Host {}: Reading pattern '{}' or '{}' was found: {}".format(
+                        self._host, pattern, base_prompt_pattern, repr(output)
+                    )
+                )
+                return output
+

--- a/netdev/vendors/alcatel/alcatel_aos.py
+++ b/netdev/vendors/alcatel/alcatel_aos.py
@@ -18,17 +18,11 @@ class AlcatelAOS(BaseDevice):
             fut = self._stdout.read(self._MAX_BUFFER)
             try:
                 output += await asyncio.wait_for(fut, self._timeout)
-                #print("123:")
-                #print(output)
-                #print("*" * 80)
             except asyncio.TimeoutError:
                 raise TimeoutError(self._host)
             if re.search("\n" + pattern, output, flags=re_flags) or re.search(
                 "\n" + base_prompt_pattern, output, flags=re_flags
             ):
-            
-            #if re.search("\nrprd-opcinet091 - ADMIN ==> ", output, flags=re_flags):
-            
                 logger.debug(
                     "Host {}: Reading pattern '{}' or '{}' was found: {}".format(
                         self._host, pattern, base_prompt_pattern, repr(output)

--- a/netdev/vendors/alcatel/alcatel_aos.py
+++ b/netdev/vendors/alcatel/alcatel_aos.py
@@ -1,0 +1,7 @@
+from netdev.vendors.base import BaseDevice
+
+
+class AlcatelAOS(BaseDevice):
+    """Class for working with Alcatel AOS"""
+
+    pass

--- a/netdev/vendors/base.py
+++ b/netdev/vendors/base.py
@@ -493,6 +493,7 @@ class BaseDevice(object):
         ESC[24;27H   Position cursor
         ESC[?25h     Show the cursor
         ESC[E        Next line (HP does ESC-E)
+        ESC[K        Erase line. Clear from cursor to end of screen
         ESC[2K       Erase line
         ESC[1;24r    Enable scrolling from start to row end
         ESC7         Save cursor position
@@ -518,6 +519,7 @@ class BaseDevice(object):
         code_position_cursor = chr(27) + r"\[\d+;\d+H"
         code_show_cursor = chr(27) + r"\[\?25h"
         code_next_line = chr(27) + r"E"
+        code_erase_line_from_cursor = chr(27) + r"\[K"
         code_erase_line = chr(27) + r"\[2K"
         code_enable_scroll = chr(27) + r"\[\d+;\d+r"
 
@@ -530,6 +532,7 @@ class BaseDevice(object):
             code_position_cursor,
             code_show_cursor,
             code_erase_line,
+            code_erase_line_from_cursor,
             code_enable_scroll,
         ]
 

--- a/netdev/vendors/cisco/__init__.py
+++ b/netdev/vendors/cisco/__init__.py
@@ -2,5 +2,6 @@ from .cisco_asa import CiscoASA
 from .cisco_ios import CiscoIOS
 from .cisco_iosxr import CiscoIOSXR
 from .cisco_nxos import CiscoNXOS
+from .cisco_sg3xx import CiscoSG3XX
 
-__all__ = ["CiscoIOS", "CiscoIOSXR", "CiscoASA", "CiscoNXOS"]
+__all__ = ["CiscoIOS", "CiscoIOSXR", "CiscoASA", "CiscoNXOS", "CiscoSG3XX"]

--- a/netdev/vendors/cisco/cisco_sg3xx.py
+++ b/netdev/vendors/cisco/cisco_sg3xx.py
@@ -1,0 +1,30 @@
+"""Subclass specific to Cisco SG3XX"""
+
+from netdev.vendors.ios_like import IOSLikeDevice
+
+class CiscoSG3XX(IOSLikeDevice):
+    """Class for working with Cisco SG3XX"""
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize class for asynchronous working with network devices
+
+        :param str host: device hostname or ip address for connection
+        :param str username: username for logging to device
+        :param str password: user password for logging to device
+        :param str secret: secret password for privilege mode
+        :param int port: ssh port for connection. Default is 22
+        :param str device_type: network device type
+        :param known_hosts: file with known hosts. Default is None (no policy). With () it will use default file
+        :param str local_addr: local address for binding source of tcp connection
+        :param client_keys: path for client keys. Default in None. With () it will use default file in OS
+        :param str passphrase: password for encrypted client keys
+        :param float timeout: timeout in second for getting information from channel
+        :param loop: asyncio loop object
+        """
+        super().__init__(*args, **kwargs)
+        self._ansi_escape_codes = True
+
+    _disable_paging_command = "terminal datadump"
+
+

--- a/tests/test_cisco_iossg3xx.py
+++ b/tests/test_cisco_iossg3xx.py
@@ -1,0 +1,88 @@
+import asyncio
+import logging
+import unittest
+
+import yaml
+
+import netdev
+
+logging.basicConfig(filename='unittest.log', level=logging.DEBUG)
+config_path = 'config.yaml'
+
+
+class TestIOSSG3XX(unittest.TestCase):
+    @staticmethod
+    def load_credits():
+        with open(config_path, 'r') as conf:
+            config = yaml.safe_load(conf)
+            with open(config['device_list'], 'r') as devs:
+                devices = yaml.safe_load(devs)
+                params = [p for p in devices if p['device_type'] == 'cisco_sg3xx']
+                return params
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.loop.set_debug(False)
+        asyncio.set_event_loop(self.loop)
+        self.devices = self.load_credits()
+        self.assertFalse(len(self.devices) == 0)
+
+    def test_show_run_hostname(self):
+        async def task():
+            for dev in self.devices:
+                async with netdev.create(**dev) as ios:
+                    out = await ios.send_command('show run | i hostname')
+                    self.assertIn("hostname", out)
+
+        self.loop.run_until_complete(task())
+
+    def test_timeout(self):
+        async def task():
+            for dev in self.devices:
+                with self.assertRaises(netdev.TimeoutError):
+                    async with netdev.create(**dev, timeout=0.1) as ios:
+                        await ios.send_command('show run | i hostname')
+
+        self.loop.run_until_complete(task())
+
+    def test_show_several_commands(self):
+        async def task():
+            for dev in self.devices:
+                async with netdev.create(**dev) as ios:
+                    commands = ["dir", "show ver", "show run", "show ssh"]
+                    for cmd in commands:
+                        out = await ios.send_command(cmd, strip_command=False)
+                        self.assertIn(cmd, out)
+
+        self.loop.run_until_complete(task())
+
+    def test_config_set(self):
+        async def task():
+            for dev in self.devices:
+                async with netdev.create(**dev) as ios:
+                    commands = ["line con", "exit"]
+                    out = await ios.send_config_set(commands)
+                    self.assertIn("line con", out)
+                    self.assertIn("exit", out)
+
+        self.loop.run_until_complete(task())
+
+    def test_base_prompt(self):
+        async def task():
+            for dev in self.devices:
+                async with netdev.create(**dev) as ios:
+                    out = await ios.send_command('sh run | i hostname')
+                    self.assertIn(ios.base_prompt, out)
+
+        self.loop.run_until_complete(task())
+
+    def test_interactive_commands(self):
+        async def task():
+            for dev in self.devices:
+                async with netdev.create(**dev) as ios:
+                    out = await ios.send_command("conf", pattern=r'\[terminal\]\?', strip_command=False)
+                    out += await ios.send_command("term", strip_command=False)
+                    out += await ios.send_command("exit", strip_command=False)
+                    self.assertIn('Enter configuration commands', out)
+
+        self.loop.run_until_complete(task())


### PR DESCRIPTION
Hello.

Netdev cannot work right now for SG3XX Cisco switch (SG300, SG350, SG350-10, etc.).

Two things are blocking the SSH requests if we use CiscoIOS class:
- the "_disable_paging_command" variable used for paging with the value "terminal length 0" should be replaced by "terminal datadump" (since "terminal length" does not exist on the device)
- The escape sequence "ESC[K" used by those switches is not taken into account so that the prompt and pattern variables are wrong (and then the end of the escape sequence is a part of the beginning of the prompt and the pattern which give a Timeout as you can imagine)

I created a new class for SG3XX Cisco switches for Netdev.

The code has been tested on a device SG350-10 but the test file "test_cisco_iossg3xx.py" is the only file not tested. Example script "cisco_sg3xx.py" has been tested and the result is inside the file as a comment.

Feel free to change the code as you wish; I am not an expert programmer...

